### PR TITLE
Fix error in Chrome+Batarang

### DIFF
--- a/ngBootbox.js
+++ b/ngBootbox.js
@@ -1,6 +1,4 @@
-angular.module('ngBootbox', function() {
-
-})
+angular.module('ngBootbox', [])
   .directive('ngBootboxAlert', function($ngBootbox) {
       return {
           restrict: 'A',


### PR DESCRIPTION
When using this module and having batarang enabled, it crashes application with following error.

https://docs.angularjs.org/error/$injector/modulerr?p0=ngHintModules&p1=TypeError:%20undefined%20is%20not%20a%20function%0A%20%20%20%20at%20module.exports%20(chrome-extension:%2F%2Fighdmehidhipcmcojjgiloacoafjmpfk%2Fdist%2Fhint.js:2335:21)%0A%20%20%20%20at%20module.exports%20(chrome-extension:%2F%2Fighdmehidhipcmcojjgiloacoafjmpfk%2Fdist%2Fhint.js:2386:5)%0A%20%20%20%20at%20chrome-extension:%2F%2Fighdmehidhipcmcojjgiloacoafjmpfk%2Fdist%2Fhint.js:2389:7%0A%20%20%20%20at%20Array.forEach%20(native)%0A%20%20%20%20at%20module.exports%20(chrome-extension:%2F%2Fighdmehidhipcmcojjgiloacoafjmpfk%2Fdist%2Fhint.js:2387:21)%0A%20%20%20%20at%20chrome-extension:%2F%2Fighdmehidhipcmcojjgiloacoafjmpfk%2Fdist%2Fhint.js:2154:3%0A%20%20%20%20at%20Object.e%20%5Bas%20invoke%5D%20(http:%2F%2Feriktufvesson.github.io%2Flib%2Fangular%2Fangular.min.js:36:365)%0A%20%20%20%20at%20d%20(http:%2F%2Feriktufvesson.github.io%2Flib%2Fangular%2Fangular.min.js:35:52)%0A%20%20%20%20at%20http:%2F%2Feriktufvesson.github.io%2Flib%2Fangular%2Fangular.min.js:35:158%0A%20%20%20%20at%20s%20(http:%2F%2Feriktufvesson.github.io%2Flib%2Fangular%2Fangular.min.js:7:302
