### PR TITLE
Making ngBootbox factory safe for minification.

### DIFF
--- a/ngBootbox.js
+++ b/ngBootbox.js
@@ -103,7 +103,7 @@ angular.module('ngBootbox', [])
           }
       };
   })
-  .factory('$ngBootbox', function($q) {
+  .factory('$ngBootbox',["$q", function($q) {
       return {
           alert: function(msg) {
               var deferred = $q.defer();
@@ -137,4 +137,4 @@ angular.module('ngBootbox', [])
               return deferred.promise;
           }
       };
-  });
+  } ]);


### PR DESCRIPTION
This change is required to allow minification of the factory.  
See:
http://stackoverflow.com/questions/15341588/angularjs-service-config-value-get-destroyed-on-minification