### PR TITLE
Use $ngBootbox service in directives

### DIFF
--- a/ngBootbox.js
+++ b/ngBootbox.js
@@ -1,19 +1,19 @@
 angular.module('ngBootbox', [])
   /* @ngInject */
-  .directive('ngBootboxAlert', function() {
+  .directive('ngBootboxAlert', function($ngBootbox) {
     return {
       restrict: 'A',
       scope: false,
       link: function (scope, element, attr) {
         var msg = attr.ngBootboxAlert || "Yo!";
         element.bind('click', function () {
-          bootbox.alert(msg);
+          $ngBootbox.alert(msg);
         });
       }
     };
   })
   /* @ngInject */
-  .directive('ngBootboxConfirm', function() {
+  .directive('ngBootboxConfirm', function($ngBootbox) {
     return {
       restrict: 'A',
       scope: {
@@ -23,20 +23,17 @@ angular.module('ngBootbox', [])
       link: function (scope, element, attr) {
         var msg = attr.ngBootboxConfirm || "Are you sure?";
         element.bind('click', function () {
-          bootbox.confirm(msg, function (result) {
-            if (result) {
-              scope.$apply(scope.actionOK);
-            }
-            else {
-              scope.$apply(scope.actionCancel);
-            }
+          $ngBootbox.confirm(msg).then(function () {
+            scope.$apply(scope.actionOK);
+          }, function () {
+            scope.$apply(scope.actionCancel);
           });
         });
       }
     };
   })
   /* @ngInject */
-  .directive('ngBootboxPrompt', function() {
+  .directive('ngBootboxPrompt', function($ngBootbox) {
     return {
       restrict: 'A',
       scope: {
@@ -45,37 +42,18 @@ angular.module('ngBootbox', [])
       },
       link: function (scope, element, attr) {
         var msg = attr.ngBootboxPrompt || "Are you sure?";
-        element.bind('click', function () {
-          bootbox.prompt(msg, function (result) {
-            if (result !== null) {
-              scope.$apply(function() { scope.actionOK({result: result}); });
-            }
-            else {
-              scope.$apply(scope.actionCancel);
-            }
+        $ngBootbox.bind('click', function () {
+          $ngBootbox.prompt(msg).then(function (result) {
+            scope.$apply(function() { scope.actionOK({result: result}); });
+          }, function() {
+            scope.$apply(scope.actionCancel);
           });
         });
       }
     };
   })
   /* @ngInject */
-  .directive('ngBootboxCustomDialog', function($templateCache, $compile, $q, $http) {
-
-    var getTemplate = function(templateId) {
-      var def = $q.defer();
-
-      var template = $templateCache.get(templateId);
-      if (typeof template === "undefined") {
-        $http.get(templateId)
-          .success(function(data) {
-            $templateCache.put(templateId, data);
-            def.resolve(data);
-          });
-      } else {
-        def.resolve(template);
-      }
-      return def.promise;
-    };
+  .directive('ngBootboxCustomDialog', function($ngBootbox) {
 
     return {
       restrict: 'A',
@@ -87,28 +65,24 @@ angular.module('ngBootbox', [])
         options: '=ngBootboxOptions'
       },
       link: function (scope, element, attr) {
-        var msg = '';
-        var templateUrl = attr.ngBootboxCustomDialogTemplate;
-        if (templateUrl) {
-          getTemplate(templateUrl).then(function(res) {
-            msg = $compile(res)(scope);
-          });
+        var options = {},
+            templateUrl = attr.ngBootboxCustomDialogTemplate;
+
+        if (scope.options) {
+          options = scope.options;
         }
-        else {
-          msg = attr.ngBootboxCustomDialog;
+        if(scope.title) options.title = scope.title;
+        if(scope.buttons) options.buttons = scope.buttons;
+        if(scope.className) options.className = scope.className;
+        if(scope.data) options.data = scope.data;
+        if( templateUrl ) {
+          options.templateUrl = templateUrl;
+        } else {
+          options.message = attr.ngBootboxCustomDialog;
         }
+
         element.bind('click', function () {
-          if (scope.options) {
-            bootbox.dialog(scope.options);
-          }
-          else {
-            bootbox.dialog({
-              message: msg,
-              title: scope.title,
-              buttons: scope.buttons,
-              className: scope.className
-            });
-          }
+          $ngBootbox.customDialog(options);
         });
       }
     };


### PR DESCRIPTION
refactoring - use $ngBootbox service in directives, remove duplicate code and resolve #11 issue

I think duplicate code in service and directives may cause similar issues as #11 in future. This way we could encapsulate functionality in service.