### PR TITLE
Set minimum AngularJS version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     ".idea"
   ],
   "dependencies": {
-    "angular": "~1.3.10",
+    "angular": ">1.3.10",
     "bootbox": "~4.4.0",
     "bootstrap": "~3.3.2",
     "jquery": "~2.1.3"


### PR DESCRIPTION
This way ngBootbox can be installed along with AngularJS 1.4. Otherwise, a bower **ECONFLICT** is risen (I'm using Angular 1.4.x in my project):

```
bower install ngBootbox
bower cached        git://github.com/eriktufvesson/ngBootbox.git#0.1.0
bower validate      0.1.0 against git://github.com/eriktufvesson/ngBootbox.git#*
bower cached        git://github.com/angular/bower-angular.git#1.3.17
bower validate      1.3.17 against git://github.com/angular/bower-angular.git#~1.3.10
bower cached        git://github.com/makeusabrew/bootbox.git#4.4.0
bower validate      4.4.0 against git://github.com/makeusabrew/bootbox.git#~4.4.0
bower cached        git://github.com/angular/bower-angular.git#1.4.3
bower validate      1.4.3 against git://github.com/angular/bower-angular.git#1.4.3
bower cached        git://github.com/angular/bower-angular.git#1.4.3
bower validate      1.4.3 against git://github.com/angular/bower-angular.git#1.2 - 1.4
bower cached        git://github.com/angular/bower-angular.git#1.4.3
bower validate      1.4.3 against git://github.com/angular/bower-angular.git#~1.x
bower cached        git://github.com/angular/bower-angular.git#1.4.3
bower validate      1.4.3 against git://github.com/angular/bower-angular.git#>=1.0.8
bower ECONFLICT     Unable to find suitable version for angular
```

I've tested ngBootbox with AngularJS 1.4 and I've found no problems running it at the moment.